### PR TITLE
Upgrade terraform to the 1.0.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "parseurl": "1.3.0",
     "pause": "0.1.0",
     "send": "0.13.0",
-    "terraform": "0.13.2"
+    "terraform": "~1.0.0"
   },
   "devDependencies": {
     "cheerio": "0.19.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "async": "0.2.9",
-    "commander": "2.0.0",
+    "commander": "2.9.0",
     "connect": "2.30.2",
     "download-github-repo": "0.1.3",
     "envy-json": "0.2.1",


### PR DESCRIPTION
This update moves harp to depend on the `1.0` release of terraform.

This adds support for some changes that @johnboxall made to terraform just before the 1.0 release. 
